### PR TITLE
feat Hologres [copy ... from stdin with (format binary, stream_mode t…

### DIFF
--- a/copy_from.go
+++ b/copy_from.go
@@ -199,7 +199,7 @@ func (ct *copyFrom) run(ctx context.Context) (int64, error) {
 		w.Close()
 	}()
 
-	commandTag, err := ct.conn.pgConn.CopyFrom(ctx, r, fmt.Sprintf("copy %s ( %s ) from stdin binary;", quotedTableName, quotedColumnNames))
+	commandTag, err := ct.conn.pgConn.CopyFrom(ctx, r, fmt.Sprintf("copy %s ( %s ) from stdin with (format binary, stream_mode true);", quotedTableName, quotedColumnNames))
 
 	r.Close()
 	<-doneChan


### PR DESCRIPTION
Hologres 在使用 copy from 时，如果指定格式为二进制时，stream_mode 的选项必须设置为 true

此提交仅为 Hologres 特性修改的，不兼容 Postgres

阿里云 Hologres 文档
https://www.alibabacloud.com/help/en/hologres/user-guide/accelerate-the-execution-of-sql-statements-by-using-fixed-plans